### PR TITLE
Add timeouts to api calls to prevent tying up server processes

### DIFF
--- a/lib/crocodoc.rb
+++ b/lib/crocodoc.rb
@@ -113,12 +113,28 @@ module Crocodoc
     result = nil
     http_code = nil
     
+    timeout = 10
     if post_params && post_params.length > 0
-      response = RestClient.post(url, post_params, params: get_params){|response, request, result| result }
+      response = RestClient::Request.execute(
+        :method => :post,
+        :url => url,
+        :payload => post_params,
+        :headers => {:params => get_params},
+        :timeout => timeout,
+        :open_timeout => timeout
+      ) {|response, request, result| result }
+
       result = RestClient::Request.decode(response['content-encoding'], response.body)
       http_code = Integer(response.code)
     else
-      response = RestClient.get(url, params: get_params){|response, request, result| result }
+      response = RestClient::Request.execute(
+        :method => :get,
+        :url => url,
+        :headers => {:params => get_params},
+        :timeout => timeout,
+        :open_timeout => timeout
+      ) {|response, request, result| result }
+
       result = RestClient::Request.decode(response['content-encoding'], response.body)
       http_code = Integer(response.code)
     end

--- a/lib/crocodoc.rb
+++ b/lib/crocodoc.rb
@@ -113,30 +113,37 @@ module Crocodoc
     result = nil
     http_code = nil
     
-    timeout = 10
-    if post_params && post_params.length > 0
-      response = RestClient::Request.execute(
-        :method => :post,
-        :url => url,
-        :payload => post_params,
-        :headers => {:params => get_params},
-        :timeout => timeout,
-        :open_timeout => timeout
-      ) {|response, request, result| result }
+    begin
+      timeout = 10
+      if post_params && post_params.length > 0
+        response = RestClient::Request.execute(
+          :method => :post,
+          :url => url,
+          :payload => post_params,
+          :headers => {:params => get_params},
+          :timeout => timeout,
+          :open_timeout => timeout
+        ) {|response, request, result| result }
 
-      result = RestClient::Request.decode(response['content-encoding'], response.body)
-      http_code = Integer(response.code)
-    else
-      response = RestClient::Request.execute(
-        :method => :get,
-        :url => url,
-        :headers => {:params => get_params},
-        :timeout => timeout,
-        :open_timeout => timeout
-      ) {|response, request, result| result }
+        result = RestClient::Request.decode(response['content-encoding'], response.body)
+        http_code = Integer(response.code)
+      else
+        response = RestClient::Request.execute(
+          :method => :get,
+          :url => url,
+          :headers => {:params => get_params},
+          :timeout => timeout,
+          :open_timeout => timeout
+        ) {|response, request, result| result }
 
-      result = RestClient::Request.decode(response['content-encoding'], response.body)
-      http_code = Integer(response.code)
+        result = RestClient::Request.decode(response['content-encoding'], response.body)
+        http_code = Integer(response.code)
+      end
+    rescue RestClient::RequestTimeout => ex
+      return self._error('server_response_timeout', self.name, __method__, {
+        get_params: get_params,
+        post_params: post_params
+      })
     end
     
     if is_json


### PR DESCRIPTION
We implemented this fix over a year ago when calls to crocodoc were taking really long times, and it caused all of our server processes to get tied up.  This fix ensures that we will timeout.